### PR TITLE
Better shop scrolling

### DIFF
--- a/gamemodes/hunters_glee/gamemode/cl_shoppinggui.lua
+++ b/gamemodes/hunters_glee/gamemode/cl_shoppinggui.lua
@@ -154,6 +154,7 @@ function termHuntOpenTheShop()
 
         if not scrollHintTime then
             scrollHintTime = now
+
         end
 
         local elapsed = now - scrollHintTime
@@ -163,7 +164,9 @@ function termHuntOpenTheShop()
             if elapsed >= scrollHintLingerDur then
                 scrollHintLingering = false
                 scrollHintTime = now
+
             end
+
         else
             local phaseDur = scrollHintPulling and scrollHintPullbackDur or scrollHintBounceDur
 
@@ -174,7 +177,9 @@ function termHuntOpenTheShop()
 
                 if scrollHintPulling then
                     scrollHintLingering = true
+
                 end
+
             end
 
             local easeFunc = scrollHintPulling and math.ease.InOutExpo or math.ease.OutBounce
@@ -182,7 +187,9 @@ function termHuntOpenTheShop()
 
             if not scrollHintPulling then
                 frac = 1 - frac
+
             end
+
         end
 
         local radius = containerHeight * scrollHintSizeMult / 2
@@ -194,8 +201,10 @@ function termHuntOpenTheShop()
 
         if scrollHintLingering then
             surface.SetDrawColor( scrollHintColorDark )
+
         else
             surface.SetDrawColor( scrollHintColorBright )
+
         end
 
         -- Bottom poly
@@ -213,6 +222,7 @@ function termHuntOpenTheShop()
             { x = x - slide + tighten, y = y, },
             { x = x - slide, y = y - radius, },
         } )
+
     end
 
 

--- a/gamemodes/hunters_glee/gamemode/cl_shoppinggui.lua
+++ b/gamemodes/hunters_glee/gamemode/cl_shoppinggui.lua
@@ -450,14 +450,35 @@ function termHuntOpenTheShop()
 
         -- make the scrollbar match the style!
         function scrollBar:Paint( w, h )
-            draw_RoundedBox( 0, 0, 0, w, h, shopItemColor )
-            draw_RoundedBox( 0, 0, 0, w, h, cantAffordOverlay )
+            local btnHeight = scrollBar.btnUp:GetTall()
+
+            draw_RoundedBox( 0, 0, btnHeight, w, h - btnHeight * 2, shopItemColor )
+            draw_RoundedBox( 0, 0, btnHeight, w, h - btnHeight * 2, cantAffordOverlay )
         end
 
         function scrollBar.btnUp:Paint( w, h )
-            draw_RoundedBox( 0, 0, 0, w, h, shopItemColor )
+            surface.SetDrawColor( shopItemColor )
+            draw.NoTexture()
+
+            local slide = h * 0.5
+
+            local function shape()
+                surface.DrawPoly( {
+                    { x = w / 2, y = 0, },
+                    { x = w, y = h - slide, },
+                    { x = w, y = h, },
+                    { x = 0, y = h, },
+                    { x = 0, y = h - slide, },
+                } )
+
+            end
+
+            shape()
+
             if not self:IsHovered() then
-                draw_RoundedBox( 0, 0, 0, w, h, notHoveredOverlay )
+                surface.SetDrawColor( notHoveredOverlay )
+                shape()
+
             end
         end
 
@@ -466,9 +487,28 @@ function termHuntOpenTheShop()
         end
 
         function scrollBar.btnDown:Paint( w, h )
-            draw_RoundedBox( 0, 0, 0, w, h, shopItemColor )
+            surface.SetDrawColor( shopItemColor )
+            draw.NoTexture()
+
+            local slide = h * 0.5
+
+            local function shape()
+                surface.DrawPoly( {
+                    { x = w, y = 0, },
+                    { x = w, y = h - slide, },
+                    { x = w / 2, y = h, },
+                    { x = 0, y = h - slide, },
+                    { x = 0, y = 0, },
+                } )
+
+            end
+
+            shape()
+
             if not self:IsHovered() then
-                draw_RoundedBox( 0, 0, 0, w, h, notHoveredOverlay )
+                surface.SetDrawColor( notHoveredOverlay )
+                shape()
+
             end
         end
 

--- a/gamemodes/hunters_glee/gamemode/cl_shoppinggui.lua
+++ b/gamemodes/hunters_glee/gamemode/cl_shoppinggui.lua
@@ -467,7 +467,9 @@ function termHuntOpenTheShop()
         end
 
         if clientsForwardKey then
-            scrollBar.btnUp:SetTooltip( "Scroll Up (" .. input.GetKeyName( clientsForwardKey ) .. ")" )
+            local name = input.GetKeyName( clientsForwardKey )
+            name = string.upper( name )
+            scrollBar.btnUp:SetTooltip( "Scroll Up (" .. name .. ")" )
 
         end
 
@@ -502,7 +504,9 @@ function termHuntOpenTheShop()
         end
 
         if clientsBackKey then
-            scrollBar.btnDown:SetTooltip( "Scroll Down (" .. input.GetKeyName( clientsBackKey ) .. ")" )
+            local name = input.GetKeyName( clientsBackKey )
+            name = string.upper( name )
+            scrollBar.btnDown:SetTooltip( "Scroll Down (" .. name .. ")" )
 
         end
 

--- a/gamemodes/hunters_glee/gamemode/cl_shoppinggui.lua
+++ b/gamemodes/hunters_glee/gamemode/cl_shoppinggui.lua
@@ -466,6 +466,11 @@ function termHuntOpenTheShop()
             draw_RoundedBox( 0, 0, btnHeight, w, h - btnHeight * 2, cantAffordOverlay )
         end
 
+        if clientsForwardKey then
+            scrollBar.btnUp:SetTooltip( "Scroll Up (" .. input.GetKeyName( clientsForwardKey ) .. ")" )
+
+        end
+
         function scrollBar.btnUp:Paint( w, h )
             surface.SetDrawColor( shopItemColor )
             draw.NoTexture()
@@ -494,6 +499,11 @@ function termHuntOpenTheShop()
 
         function scrollBar.btnUp:Think()
             pressableThink( self )
+        end
+
+        if clientsBackKey then
+            scrollBar.btnDown:SetTooltip( "Scroll Down (" .. input.GetKeyName( clientsBackKey ) .. ")" )
+
         end
 
         function scrollBar.btnDown:Paint( w, h )
@@ -1062,6 +1072,7 @@ function termHuntOpenTheShop()
 
                     end
 
+                    -- draw the scroll hint!
                     if myCategoryPanel.canScrollRight and not scrollHintsAcknowledged[ category ] then
                         local w = self:GetWide()
                         local endX = self:LocalToScreen( w )
@@ -1069,6 +1080,7 @@ function termHuntOpenTheShop()
 
                         if endX >= endXView then
                             drawScrollHint( w * 0.45, self:GetTall() * 0.7, self:GetTall() )
+
                         end
                     end
 

--- a/gamemodes/hunters_glee/gamemode/cl_shoppinggui.lua
+++ b/gamemodes/hunters_glee/gamemode/cl_shoppinggui.lua
@@ -34,6 +34,7 @@ local draw_RoundedBox = draw.RoundedBox
 
 local lastScroll = 0
 local MAINSCROLLNAME = "main_scroll_window"
+local scrollHintsAcknowledged = {}
 
 local noDataMateiral = Material( "vgui/hud/gleenodata.png", "noclamp" )
 local dataMaterial = Material( "vgui/hud/gleefulldata.png", "noclamp smooth" )
@@ -59,20 +60,28 @@ function termHuntOpenTheShop()
     local pressableThink = GAMEMODE.shopStandards.pressableThink
     local isHovered = GAMEMODE.shopStandards.isHovered
 
-    local white =               GAMEMODE.shopStandards.white
-    local whiteFaded =          GAMEMODE.shopStandards.whiteFaded
+    local white =                 GAMEMODE.shopStandards.white
+    local whiteFaded =            GAMEMODE.shopStandards.whiteFaded
 
-    local backgroundColor =     GAMEMODE.shopStandards.backgroundColor
-    local invisibleColor =      GAMEMODE.shopStandards.invisibleColor
-    local shopItemColor =       GAMEMODE.shopStandards.shopItemColor
-    local shopScrollGradient =  GAMEMODE.shopStandards.shopScrollGradient
-    local cantAffordOverlay =   GAMEMODE.shopStandards.cantAffordOverlay
-    local scrollEndsOverlay =   GAMEMODE.shopStandards.scrollEndsOverlay
-    local notHoveredOverlay =   GAMEMODE.shopStandards.notHoveredOverlay
-    local pressedItemOverlay =  GAMEMODE.shopStandards.pressedItemOverlay
-    local markupTextColor =     GAMEMODE.shopStandards.markupTextColor
+    local backgroundColor =       GAMEMODE.shopStandards.backgroundColor
+    local invisibleColor =        GAMEMODE.shopStandards.invisibleColor
+    local shopItemColor =         GAMEMODE.shopStandards.shopItemColor
+    local shopScrollGradient =    GAMEMODE.shopStandards.shopScrollGradient
+    local cantAffordOverlay =     GAMEMODE.shopStandards.cantAffordOverlay
+    local scrollEndsOverlay =     GAMEMODE.shopStandards.scrollEndsOverlay
+    local notHoveredOverlay =     GAMEMODE.shopStandards.notHoveredOverlay
+    local pressedItemOverlay =    GAMEMODE.shopStandards.pressedItemOverlay
+    local markupTextColor =       GAMEMODE.shopStandards.markupTextColor
 
-    local switchSound =         GAMEMODE.shopStandards.switchSound
+    local scrollHintColorDark =   GAMEMODE.shopStandards.scrollHintColorDark
+    local scrollHintColorBright = GAMEMODE.shopStandards.scrollHintColorBright
+    local scrollHintPullbackDur = GAMEMODE.shopStandards.scrollHintPullbackDur
+    local scrollHintBounceDur =   GAMEMODE.shopStandards.scrollHintBounceDur
+    local scrollHintLingerDur =   GAMEMODE.shopStandards.scrollHintLingerDur
+    local scrollHintSizeMult =    GAMEMODE.shopStandards.scrollHintSizeMult
+    local scrollHintMoveMult =    GAMEMODE.shopStandards.scrollHintMoveMult
+
+    local switchSound =           GAMEMODE.shopStandards.switchSound
 
     local ply = LocalPlayer()
     ply.oldScrollPositions = ply.oldScrollPositions or {}
@@ -135,6 +144,77 @@ function termHuntOpenTheShop()
         clientsRightKey = input.GetKeyCode( clientsRightKey )
 
     end
+
+    local scrollHintPulling = true
+    local scrollHintLingering = false
+    local scrollHintTime = nil -- Time of start of current pull/bounce phase
+
+    local function drawScrollHint( x, y, containerHeight )
+        local now = RealTime()
+
+        if not scrollHintTime then
+            scrollHintTime = now
+        end
+
+        local elapsed = now - scrollHintTime
+        local frac = 0
+
+        if scrollHintLingering then
+            if elapsed >= scrollHintLingerDur then
+                scrollHintLingering = false
+                scrollHintTime = now
+            end
+        else
+            local phaseDur = scrollHintPulling and scrollHintPullbackDur or scrollHintBounceDur
+
+            if elapsed >= phaseDur then
+                elapsed = 0
+                scrollHintPulling = not scrollHintPulling
+                scrollHintTime = now
+
+                if scrollHintPulling then
+                    scrollHintLingering = true
+                end
+            end
+
+            local easeFunc = scrollHintPulling and math.ease.InOutExpo or math.ease.OutBounce
+            frac = easeFunc( elapsed / phaseDur )
+
+            if not scrollHintPulling then
+                frac = 1 - frac
+            end
+        end
+
+        local radius = containerHeight * scrollHintSizeMult / 2
+        local slide = radius * 1.5
+        local tighten = slide * 0.5
+        x = x - frac * radius * scrollHintMoveMult
+
+        draw.NoTexture()
+
+        if scrollHintLingering then
+            surface.SetDrawColor( scrollHintColorDark )
+        else
+            surface.SetDrawColor( scrollHintColorBright )
+        end
+
+        -- Bottom poly
+        surface.DrawPoly( {
+            { x = x, y = y, },
+            { x = x - slide + tighten, y = y + radius, },
+            { x = x - slide, y = y + radius, },
+            { x = x - slide + tighten, y = y, },
+        } )
+
+        -- Top poly
+        surface.DrawPoly( {
+            { x = x - slide + tighten, y = y - radius, },
+            { x = x, y = y, },
+            { x = x - slide + tighten, y = y, },
+            { x = x - slide, y = y - radius, },
+        } )
+    end
+
 
     -- if pressed button that opened shop, close the shop
     function shopFrame:OnKeyCodePressed( pressed )
@@ -537,6 +617,8 @@ function termHuntOpenTheShop()
 
                 end
 
+                scrollHintsAcknowledged[ category ] = true
+
                 return true
 
             end
@@ -928,6 +1010,16 @@ function termHuntOpenTheShop()
                         self.myOverlayColor = pressedItemOverlay
                         draw_RoundedBox( 0, 0, 0, self:GetWide(), self:GetTall(), self.myOverlayColor )
 
+                    end
+
+                    if myCategoryPanel.canScrollRight and not scrollHintsAcknowledged[ category ] then
+                        local w = self:GetWide()
+                        local endX = self:LocalToScreen( w )
+                        local endXView = myCategoryPanel:LocalToScreen( myCategoryPanel:GetWide() )
+
+                        if endX >= endXView then
+                            drawScrollHint( w * 0.45, self:GetTall() * 0.7, self:GetTall() )
+                        end
                     end
 
                     local score = ply:GetScore()

--- a/gamemodes/hunters_glee/gamemode/cl_shopstandards.lua
+++ b/gamemodes/hunters_glee/gamemode/cl_shopstandards.lua
@@ -197,3 +197,11 @@ GAMEMODE.shopStandards.borderPadding = 27
 GAMEMODE.shopStandards.whiteIdentifierLineWidthDiv = 250
 GAMEMODE.shopStandards.shopCategoryHeight = 275
 GAMEMODE.shopStandards.shopScrollGradientWidth = 130
+
+GAMEMODE.shopStandards.scrollHintColorDark = Color( 230, 230, 230, 230 )
+GAMEMODE.shopStandards.scrollHintColorBright = Color( 255, 255, 255, 230 )
+GAMEMODE.shopStandards.scrollHintPullbackDur = 2
+GAMEMODE.shopStandards.scrollHintBounceDur = 0.5
+GAMEMODE.shopStandards.scrollHintLingerDur = 1
+GAMEMODE.shopStandards.scrollHintSizeMult = 0.4
+GAMEMODE.shopStandards.scrollHintMoveMult = 1


### PR DESCRIPTION
Adds animated arrows to the shop which further hint to the player that it can be scrolled horizontally. They disappear for the rest of the session once their respective shop category has been scrolled at least once.

Also tweaks the appearance of the shop's vertical scrollbar for more visual clarity without breaking the UI style. Should be enough to allow more categories to be added without making the UX too clunky.

https://github.com/user-attachments/assets/17035d28-dfc1-4644-9ab9-cdc91cfa334f

https://github.com/user-attachments/assets/7efcd892-77f8-4eba-8a2e-8757186e7d76


